### PR TITLE
Add property of progress indicator's background image

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ If you do not want the opacity transition of child then set `showChildOpacityTra
 | showChildOpacityTransition            | bool                        | Whether to show child opacity transition or not.             |         true          |
 | color                                 | Color                       | The progress indicator's foreground color.                   | ThemeData.accentColor |
 | backgroundColor                       | Color                       | The progress indicator's background color.                   | ThemeData.canvasColor |
+| backgroundImage                       | ImageProvider               | The progress indicator's background image.                   | null |
 | notificationPredicate                 | ScrollNotificationPredicate | A check that specifies whether a `ScrollNotification` should be handled by this widget. |         null          |
 | scrollController                      | ScrollController            | Controls the `ScrollView` child.                             |         null          |
 

--- a/lib/liquid_pull_to_refresh.dart
+++ b/lib/liquid_pull_to_refresh.dart
@@ -51,6 +51,7 @@ class LiquidPullToRefresh extends StatefulWidget {
     @required this.onRefresh,
     this.color,
     this.backgroundColor,
+    this.backgroundImage,
     this.notificationPredicate = defaultScrollNotificationPredicate,
     this.height,
     this.springAnimationDurationInMilliseconds = 1000,
@@ -104,6 +105,10 @@ class LiquidPullToRefresh extends StatefulWidget {
   /// The progress indicator's background color. The current theme's
   /// [ThemeData.canvasColor] by default.
   final Color backgroundColor;
+
+  /// The progress indicator's background image.
+  /// [null] by default.
+  final ImageProvider backgroundImage;
 
   /// A check that specifies whether a [ScrollNotification] should be
   /// handled by this widget.
@@ -734,6 +739,7 @@ class _LiquidPullToRefreshState extends State<LiquidPullToRefresh>
                   alignment: FractionalOffset.center,
                   child: CircularProgress(
                     backgroundColor: backgroundColor,
+                    backgroundImage: widget.backgroundImage,
                     progressCircleOpacity: _ringOpacityAnimation.value,
                     innerCircleRadius: height *
                         15 /

--- a/lib/src/circular_progress.dart
+++ b/lib/src/circular_progress.dart
@@ -10,6 +10,7 @@ class CircularProgress extends StatefulWidget {
   final double progressCircleRadius;
   final double progressCircleBorderWidth;
   final Color backgroundColor;
+  final ImageProvider backgroundImage;
   final double startAngle;
 
   const CircularProgress({
@@ -19,6 +20,7 @@ class CircularProgress extends StatefulWidget {
     this.progressCircleRadius,
     this.progressCircleBorderWidth,
     this.backgroundColor,
+    this.backgroundImage,
     this.progressCircleOpacity,
     this.startAngle,
   }) : super(key: key);
@@ -61,6 +63,12 @@ class _CircularProgressState extends State<CircularProgress> {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: widget.backgroundColor,
+                image: widget.backgroundImage == null
+                    ? null
+                    : DecorationImage(
+                        fit: BoxFit.fill,
+                        image: widget.backgroundImage,
+                      ),
               ),
             ),
           )


### PR DESCRIPTION
referred  issue https://github.com/aagarwal1012/Liquid-Pull-To-Refresh/issues/14

add `backgroundImage` property at LiquidPullToRefresh.

## Sample

```diff
# example/lib/main.dart
~~~
body: LiquidPullToRefresh(
        key: _refreshIndicatorKey,
        onRefresh: _handleRefresh,
+       backgroundImage: Image.network("http://placehold.jp/150x150.png").image,
~~~
```

I would be happy if you could check it. 🙏