### PR TITLE
Moved away from the accent color and replaced with colorScheme.secondary

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ If you do not want the opacity transition of child then set `showChildOpacityTra
 | springAnimationDurationInMilliseconds | int             | Duration in milliseconds of springy effect that occurs when we leave dragging after full drag.         |         1000          |
 | borderWidth                           | double          | Border width of progressing circle in Progressing Indicator.                                           |          2.0          |
 | showChildOpacityTransition            | bool            | Whether to show child opacity transition or not.                                                       |         true          |
-| color                                 | Color           | The progress indicator's foreground color.                                                             | ThemeData.accentColor |
+| color                                 | Color           | The progress indicator's foreground color.                                                             | ColorScheme.secondary |
 | backgroundColor                       | Color           | The progress indicator's background color.                                                             | ThemeData.canvasColor |
 | animSpeedFactor                       | double          | Controls the speed of the animation after refresh. Used to fasten the ending animation.                |          1.0          |
 

--- a/lib/liquid_pull_to_refresh.dart
+++ b/lib/liquid_pull_to_refresh.dart
@@ -103,7 +103,7 @@ class LiquidPullToRefresh extends StatefulWidget {
   final RefreshCallback onRefresh;
 
   /// The progress indicator's foreground color. The current theme's
-  /// [ThemeData.accentColor] by default.
+  /// [Theme.of(context).colorScheme.secondary] by default.
   final Color? color;
 
   /// The progress indicator's background color. The current theme's
@@ -234,8 +234,8 @@ class LiquidPullToRefreshState extends State<LiquidPullToRefresh>
     final ThemeData theme = Theme.of(context);
     _valueColor = _positionController.drive(
       ColorTween(
-              begin: (widget.color ?? theme.accentColor).withOpacity(0.0),
-              end: (widget.color ?? theme.accentColor).withOpacity(1.0))
+              begin: (widget.color ?? theme.colorScheme.secondary).withOpacity(0.0),
+              end: (widget.color ?? theme.colorScheme.secondary).withOpacity(1.0))
           .chain(CurveTween(
               curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit))),
     );
@@ -577,7 +577,7 @@ class LiquidPullToRefreshState extends State<LiquidPullToRefresh>
     assert(debugCheckHasMaterialLocalizations(context));
 
     // assigning default color and background color
-    Color _defaultColor = Theme.of(context).accentColor;
+    Color _defaultColor = Theme.of(context).colorScheme.secondary;
     Color _defaultBackgroundColor = Theme.of(context).canvasColor;
 
     // assigning default height


### PR DESCRIPTION
## Pull Request Process
Fix for #60 and changed dependency on deprecated accentColor value, and updated readme to reflect this change.